### PR TITLE
chore!: change lib name for llmberjack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [WIP] LLM Adapter
+# LLMberjack 🪵🪓🦊
 
 Type-safe wrapper adapter around various LLM providers.
 
@@ -8,7 +8,7 @@ _Note:_ this library is a very early preview, meaning it will have major breakin
 
 ### Basic setup
 
-LLM Adapter is used by setting up an instance of it with _at least_ one provider. An adapter can be configured with more (named) providers, which can be selected by their names when sending requests.
+LLMberjack is used by setting up an instance of it with _at least_ one provider. An adapter can be configured with more (named) providers, which can be selected by their names when sending requests.
 
 ```go
 gpt, err := openai.New(openai.WithApiKey("..."))

--- a/adapter.go
+++ b/adapter.go
@@ -1,11 +1,11 @@
-package llmadapter
+package llmberjack
 
 import (
 	"context"
 	"net/http"
 	"reflect"
 
-	"github.com/checkmarble/llm-adapter/internal"
+	"github.com/checkmarble/llmberjack/internal"
 	"github.com/cockroachdb/errors"
 )
 
@@ -37,9 +37,9 @@ type Llm interface {
 	RequestOptionsType() reflect.Type
 }
 
-// LlmAdapter is the main entrypoint for interacting with different LLM providers.
+// llmberjack is the main entrypoint for interacting with different LLM providers.
 // It provides a unified interface to send requests and receive responses.
-type LlmAdapter struct {
+type llmberjack struct {
 	providers       map[string]Llm
 	defaultProvider Llm
 
@@ -47,18 +47,18 @@ type LlmAdapter struct {
 	defaultModel string
 }
 
-// New creates a new LlmAdapter with the given options.
+// New creates a new llmberjack with the given options.
 // It initializes the specified LLM provider and returns a configured adapter.
 //
 // Example usage:
 //
-//	adapter, err := llmadapter.New(
-//		llmadapter.WithDefaultProvider(provider),
-//		llmadapter.WithDefaultModel("gpt-4"),
-//		llmadapter.WithApiKey("...")
+//	adapter, err := llmberjack.New(
+//		llmberjack.WithDefaultProvider(provider),
+//		llmberjack.WithDefaultModel("gpt-4"),
+//		llmberjack.WithApiKey("...")
 //	)
-func New(opts ...llmOption) (*LlmAdapter, error) {
-	llm := LlmAdapter{
+func New(opts ...llmOption) (*llmberjack, error) {
+	llm := llmberjack{
 		providers: make(map[string]Llm),
 	}
 
@@ -80,7 +80,7 @@ func New(opts ...llmOption) (*LlmAdapter, error) {
 // new adapter instance. This also clears the systems instructions.
 // If called without arguments, will clear the history of the default provider,
 // otherwise, it accepts variadic provider names for which to clear the history.
-// func (llm *LlmAdapter) ResetThreads(threadIds ...*ThreadId) {
+// func (llm *llmberjack) ResetThreads(threadIds ...*ThreadId) {
 // 	for _, thread := range threadIds {
 // 		thread.provider.ResetThread(thread)
 // 	}
@@ -90,7 +90,7 @@ func New(opts ...llmOption) (*LlmAdapter, error) {
 // It accepts the provider requested in a specific request, which will override
 // the default provider. If the provider argument is nil, it will return the
 // configured default provider.
-func (llm *LlmAdapter) GetProvider(requestProvider *string) (Llm, error) {
+func (llm *llmberjack) GetProvider(requestProvider *string) (Llm, error) {
 	if llm.defaultProvider == nil {
 		return nil, errors.New("no provider was configured")
 	}
@@ -109,12 +109,12 @@ func (llm *LlmAdapter) GetProvider(requestProvider *string) (Llm, error) {
 	return provider, nil
 }
 
-// LlmAdapter implementation of Adapter
+// llmberjack implementation of Adapter
 
-func (llm LlmAdapter) DefaultModel() string {
+func (llm llmberjack) DefaultModel() string {
 	return llm.defaultModel
 }
 
-func (llm LlmAdapter) HttpClient() *http.Client {
+func (llm llmberjack) HttpClient() *http.Client {
 	return llm.httpClient
 }

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"reflect"

--- a/examples/async/main.go
+++ b/examples/async/main.go
@@ -6,9 +6,9 @@ import (
 	"log"
 	"os"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
-	"github.com/checkmarble/llm-adapter/llms/aistudio"
-	"github.com/checkmarble/llm-adapter/llms/openai"
+	llmberjack "github.com/checkmarble/llmberjack"
+	"github.com/checkmarble/llmberjack/llms/aistudio"
+	"github.com/checkmarble/llmberjack/llms/openai"
 	"google.golang.org/genai"
 )
 
@@ -18,18 +18,18 @@ func main() {
 	ollama, _ := openai.New(openai.WithBaseUrl("http://localhost:11434/v1"))
 	gemini, _ := aistudio.New(aistudio.WithBackend(genai.BackendGeminiAPI), aistudio.WithApiKey(os.Getenv("LLM_API_KEY")))
 
-	llm, _ := llmadapter.New(
-		llmadapter.WithProvider("ollama", ollama),
-		llmadapter.WithProvider("gemini", gemini),
-		llmadapter.WithDefaultModel("gemma3n:e4b"),
+	llm, _ := llmberjack.New(
+		llmberjack.WithProvider("ollama", ollama),
+		llmberjack.WithProvider("gemini", gemini),
+		llmberjack.WithDefaultModel("gemma3n:e4b"),
 	)
 
 	fmt.Println("All()")
 
-	resps := llmadapter.All(
+	resps := llmberjack.All(
 		ctx, llm,
-		llmadapter.NewUntypedRequest().WithProvider("ollama").WithText(llmadapter.RoleUser, "How are you?"),
-		llmadapter.NewUntypedRequest().WithProvider("gemini").WithModel("gemini-2.5-flash").WithText(llmadapter.RoleUser, "Compute 1 + 1."),
+		llmberjack.NewUntypedRequest().WithProvider("ollama").WithText(llmberjack.RoleUser, "How are you?"),
+		llmberjack.NewUntypedRequest().WithProvider("gemini").WithModel("gemini-2.5-flash").WithText(llmberjack.RoleUser, "Compute 1 + 1."),
 	)
 
 	for _, resp := range resps {
@@ -46,10 +46,10 @@ func main() {
 
 	fmt.Println("Race()")
 
-	resp, err := llmadapter.Race(
+	resp, err := llmberjack.Race(
 		ctx, llm,
-		llmadapter.NewUntypedRequest().WithProvider("ollama").WithText(llmadapter.RoleUser, "How are you?"),
-		llmadapter.NewUntypedRequest().WithProvider("gemini").WithText(llmadapter.RoleUser, "Compute 1 + 1."),
+		llmberjack.NewUntypedRequest().WithProvider("ollama").WithText(llmberjack.RoleUser, "How are you?"),
+		llmberjack.NewUntypedRequest().WithProvider("gemini").WithText(llmberjack.RoleUser, "Compute 1 + 1."),
 	)
 
 	if err != nil {

--- a/examples/full/main.go
+++ b/examples/full/main.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"os"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
-	"github.com/checkmarble/llm-adapter/llms/aistudio"
+	llmberjack "github.com/checkmarble/llmberjack"
+	"github.com/checkmarble/llmberjack/llms/aistudio"
 	"google.golang.org/genai"
 )
 
@@ -29,19 +29,19 @@ func main() {
 		log.Fatal(err)
 	}
 
-	llm, err := llmadapter.New(
-		llmadapter.WithProvider("vertex", provider),
-		llmadapter.WithDefaultModel("gemini-2.5-pro"),
+	llm, err := llmberjack.New(
+		llmberjack.WithProvider("vertex", provider),
+		llmberjack.WithDefaultModel("gemini-2.5-pro"),
 	)
 
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	resp1, err := llmadapter.NewRequest[Output]().
+	resp1, err := llmberjack.NewRequest[Output]().
 		CreateThread().
 		WithInstructionFiles("prompts/system.txt").
-		WithText(llmadapter.RoleUser, "Hello, my name is Bob!").
+		WithText(llmberjack.RoleUser, "Hello, my name is Bob!").
 		Do(ctx, llm)
 
 	if err != nil {
@@ -54,9 +54,9 @@ func main() {
 
 	fmt.Println("Reply:", out.Reply, "Random:", out.Random)
 
-	resp2, err := llmadapter.NewUntypedRequest().
+	resp2, err := llmberjack.NewUntypedRequest().
 		FromCandidate(resp1, 0).
-		WithText(llmadapter.RoleUser, "Do you remember what my name is? Also, append your previous response.").
+		WithText(llmberjack.RoleUser, "Do you remember what my name is? Also, append your previous response.").
 		Do(ctx, llm)
 
 	if err != nil {
@@ -71,7 +71,7 @@ func main() {
 		Location string `json:"location" jsonschema_description:"The location for which to retrieve the weather forecast"`
 	}
 
-	weatherTool := llmadapter.NewTool[WeatherToolParams]("get_weather_in_location", "Get a weather forecast in a given location", llmadapter.Function(func(p WeatherToolParams) (string, error) {
+	weatherTool := llmberjack.NewTool[WeatherToolParams]("get_weather_in_location", "Get a weather forecast in a given location", llmberjack.Function(func(p WeatherToolParams) (string, error) {
 		return "Weather is going to be very rainy with chance of thunderstorms", nil
 	}))
 
@@ -79,10 +79,10 @@ func main() {
 		log.Fatal(weatherTool)
 	}
 
-	resp3, err := llmadapter.NewUntypedRequest().
+	resp3, err := llmberjack.NewUntypedRequest().
 		CreateThread().
 		FromCandidate(resp2, 0).
-		WithText(llmadapter.RoleUser, "Tell me the weather in Paris.").
+		WithText(llmberjack.RoleUser, "Tell me the weather in Paris.").
 		WithTools(weatherTool).
 		Do(ctx, llm)
 
@@ -92,7 +92,7 @@ func main() {
 
 	defer resp3.ThreadId.Close()
 
-	resp4, err := llmadapter.NewUntypedRequest().
+	resp4, err := llmberjack.NewUntypedRequest().
 		FromCandidate(resp3, 0).
 		WithToolExecution(weatherTool).
 		Do(ctx, llm)

--- a/examples/grounding/main.go
+++ b/examples/grounding/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
-	"github.com/checkmarble/llm-adapter/llms/aistudio"
+	llmberjack "github.com/checkmarble/llmberjack"
+	"github.com/checkmarble/llmberjack/llms/aistudio"
 	"github.com/samber/lo"
 	"google.golang.org/genai"
 )
@@ -15,16 +15,16 @@ func main() {
 	ctx := context.Background()
 
 	provider, _ := aistudio.New(aistudio.WithBackend(genai.BackendGeminiAPI), aistudio.WithApiKey(os.Getenv("LLM_API_KEY")))
-	llm, _ := llmadapter.New(
-		llmadapter.WithProvider("vertex", provider),
-		llmadapter.WithDefaultModel("gemini-2.5-flash"),
+	llm, _ := llmberjack.New(
+		llmberjack.WithProvider("vertex", provider),
+		llmberjack.WithDefaultModel("gemini-2.5-flash"),
 	)
 
-	resp, _ := llmadapter.NewUntypedRequest().
+	resp, _ := llmberjack.NewUntypedRequest().
 		WithProviderOptions(aistudio.RequestOptions{
 			GoogleSearch: lo.ToPtr(true),
 		}).
-		WithText(llmadapter.RoleUser, "When was the Madleen ship stopped when trying to reach Gaza?").
+		WithText(llmberjack.RoleUser, "When was the Madleen ship stopped when trying to reach Gaza?").
 		Do(ctx, llm)
 
 	candidate, _ := resp.Candidate(0)

--- a/examples/multiple/main.go
+++ b/examples/multiple/main.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
-	"github.com/checkmarble/llm-adapter/llms/aistudio"
-	"github.com/checkmarble/llm-adapter/llms/openai"
+	llmberjack "github.com/checkmarble/llmberjack"
+	"github.com/checkmarble/llmberjack/llms/aistudio"
+	"github.com/checkmarble/llmberjack/llms/openai"
 	"google.golang.org/genai"
 )
 
@@ -17,16 +17,16 @@ func main() {
 	gemini, _ := aistudio.New(aistudio.WithBackend(genai.BackendGeminiAPI), aistudio.WithApiKey(os.Getenv("LLM_API_KEY")))
 	ollama, _ := openai.New(openai.WithBaseUrl("http://localhost:11434/v1"))
 
-	llm, _ := llmadapter.New(
-		llmadapter.WithProvider("vertex", gemini),
-		llmadapter.WithProvider("ollama", ollama),
-		llmadapter.WithDefaultModel("gemini-2.5-flash"),
+	llm, _ := llmberjack.New(
+		llmberjack.WithProvider("vertex", gemini),
+		llmberjack.WithProvider("ollama", ollama),
+		llmberjack.WithDefaultModel("gemini-2.5-flash"),
 	)
 
-	ollamaResponse, _ := llmadapter.NewUntypedRequest().WithProvider("ollama").WithModel("gemma3n:e4b").WithText(llmadapter.RoleUser, "How are you?").Do(ctx, llm)
+	ollamaResponse, _ := llmberjack.NewUntypedRequest().WithProvider("ollama").WithModel("gemma3n:e4b").WithText(llmberjack.RoleUser, "How are you?").Do(ctx, llm)
 	ollamaCandidate, _ := ollamaResponse.Candidate(0)
 
-	geminiResponse, _ := llmadapter.NewUntypedRequest().WithText(llmadapter.RoleUser, "How are you?").Do(ctx, llm)
+	geminiResponse, _ := llmberjack.NewUntypedRequest().WithText(llmberjack.RoleUser, "How are you?").Do(ctx, llm)
 	geminiCandidate, _ := geminiResponse.Candidate(0)
 
 	fmt.Println(ollamaResponse.Model, "said", ollamaCandidate.Text)

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
-	"github.com/checkmarble/llm-adapter/llms/openai"
+	llmberjack "github.com/checkmarble/llmberjack"
+	"github.com/checkmarble/llmberjack/llms/openai"
 )
 
 func main() {
@@ -13,12 +13,12 @@ func main() {
 
 	ollama, _ := openai.New(openai.WithBaseUrl("http://localhost:11434/v1"))
 
-	llm, _ := llmadapter.New(
-		llmadapter.WithProvider("ollama", ollama),
-		llmadapter.WithDefaultModel("gemma3n:e4b"),
+	llm, _ := llmberjack.New(
+		llmberjack.WithProvider("ollama", ollama),
+		llmberjack.WithDefaultModel("gemma3n:e4b"),
 	)
 
-	resp, _ := llmadapter.NewUntypedRequest().WithProvider("ollama").WithText(llmadapter.RoleUser, "How are you?").Do(ctx, llm)
+	resp, _ := llmberjack.NewUntypedRequest().WithProvider("ollama").WithText(llmberjack.RoleUser, "How are you?").Do(ctx, llm)
 
 	fmt.Println(resp)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/checkmarble/llm-adapter
+module github.com/checkmarble/llmberjack
 
 go 1.24.4
 

--- a/history.go
+++ b/history.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"sync"

--- a/history_test.go
+++ b/history_test.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"testing"

--- a/internal/interface.go
+++ b/internal/interface.go
@@ -3,7 +3,7 @@ package internal
 import "net/http"
 
 // Adapter defines the interface for internal configuration and utility methods
-// that LLM providers can access from the main LlmAdapter.
+// that LLM providers can access from the main llmberjack.
 type Adapter interface {
 	// DefaultModel returns the default model name configured for the adapter.
 	DefaultModel() string

--- a/internal/tools.go
+++ b/internal/tools.go
@@ -38,7 +38,7 @@ func NewTool[A any](name, description string, fn FunctionBody) Tool {
 // FunctionBody is a wrapper around the tool function pointer.
 //
 // It is private so the only way to create it is through the
-// llmadapter.Function[A]() function, which ensures the argument is of the shape
+// llmberjack.Function[A]() function, which ensures the argument is of the shape
 // `func(a) (string, error)`.
 type FunctionBody struct {
 	Inner any

--- a/llms/aistudio/aistudio_test.go
+++ b/llms/aistudio/aistudio_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
-	"github.com/checkmarble/llm-adapter/llms/aistudio"
+	llmberjack "github.com/checkmarble/llmberjack"
+	"github.com/checkmarble/llmberjack/llms/aistudio"
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
@@ -45,17 +45,17 @@ func TestGoogleAiRequest(t *testing.T) {
 
 	httpClient := &http.Client{}
 	provider, _ := aistudio.New(aistudio.WithBackend(genai.BackendVertexAI), aistudio.WithLocation("location"), aistudio.WithProject("project"))
-	llm, _ := llmadapter.New(llmadapter.WithDefaultProvider(provider), llmadapter.WithHttpClient(httpClient))
+	llm, _ := llmberjack.New(llmberjack.WithDefaultProvider(provider), llmberjack.WithHttpClient(httpClient))
 
-	req := llmadapter.NewRequest[Output]().
+	req := llmberjack.NewRequest[Output]().
 		WithModel("themodel").
 		WithInstruction("system text").
 		WithInstructionReader(strings.NewReader("text from reader")).
-		WithText(llmadapter.RoleUser, "user text").
-		WithTools(llmadapter.NewTool[Args]("thetool", "Tool to get nothing", llmadapter.Function(func(Args) (string, error) {
+		WithText(llmberjack.RoleUser, "user text").
+		WithTools(llmberjack.NewTool[Args]("thetool", "Tool to get nothing", llmberjack.Function(func(Args) (string, error) {
 			return "OK", nil
 		}))).
-		WithTextReader(llmadapter.RoleUser, strings.NewReader("text from reader"))
+		WithTextReader(llmberjack.RoleUser, strings.NewReader("text from reader"))
 
 	gock.InterceptClient(httpClient)
 
@@ -109,7 +109,7 @@ func TestGoogleAiRequest(t *testing.T) {
 	candidate, err := resp.Candidate(0)
 
 	assert.Nil(t, err)
-	assert.Equal(t, llmadapter.FinishReasonStop, candidate.FinishReason)
+	assert.Equal(t, llmberjack.FinishReasonStop, candidate.FinishReason)
 
 	output, err := resp.Get(0)
 

--- a/llms/openai/adapter_test.go
+++ b/llms/openai/adapter_test.go
@@ -4,17 +4,17 @@ import (
 	"strings"
 	"testing"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
+	llmberjack "github.com/checkmarble/llmberjack"
 	"github.com/invopop/jsonschema"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestRequestAdapter(t *testing.T) {
-	llm, _ := llmadapter.New()
+	llm, _ := llmberjack.New()
 	p, _ := New()
 
 	t.Run("with model", func(t *testing.T) {
-		req := llmadapter.NewUntypedRequest().
+		req := llmberjack.NewUntypedRequest().
 			WithModel("themodel")
 
 		cfg, err := p.adaptRequest(llm, req)
@@ -24,7 +24,7 @@ func TestRequestAdapter(t *testing.T) {
 	})
 
 	t.Run("with system prompts", func(t *testing.T) {
-		req := llmadapter.NewUntypedRequest().
+		req := llmberjack.NewUntypedRequest().
 			WithModel("themodel").
 			WithInstruction("system prompt", "system prompt 2").
 			WithInstructionReader(strings.NewReader("system prompt 3"))
@@ -40,9 +40,9 @@ func TestRequestAdapter(t *testing.T) {
 	})
 
 	t.Run("with user prompts", func(t *testing.T) {
-		req := llmadapter.NewUntypedRequest().
-			WithText(llmadapter.RoleUser, "user prompt", "user prompt 2").
-			WithTextReader(llmadapter.RoleUser, strings.NewReader("user prompt 3"))
+		req := llmberjack.NewUntypedRequest().
+			WithText(llmberjack.RoleUser, "user prompt", "user prompt 2").
+			WithTextReader(llmberjack.RoleUser, strings.NewReader("user prompt 3"))
 
 		cfg, err := p.adaptRequest(llm, req)
 
@@ -62,12 +62,12 @@ func TestRequestAdapter(t *testing.T) {
 			Text string `json:"text" jsonschema_description:"Text description"`
 		}
 
-		req := llmadapter.NewUntypedRequest().
+		req := llmberjack.NewUntypedRequest().
 			WithTools(
-				llmadapter.NewTool[Args1]("toolname", "tooldesc", llmadapter.Function(func(a Args1) (string, error) {
+				llmberjack.NewTool[Args1]("toolname", "tooldesc", llmberjack.Function(func(a Args1) (string, error) {
 					return "", nil
 				})),
-				llmadapter.NewTool[Args2]("toolname 2", "tooldesc 2", llmadapter.Function(func(a Args2) (string, error) {
+				llmberjack.NewTool[Args2]("toolname 2", "tooldesc 2", llmberjack.Function(func(a Args2) (string, error) {
 					return "", nil
 				})),
 			)
@@ -111,7 +111,7 @@ func TestRequestAdapter(t *testing.T) {
 			Number int    `json:"number" jsonschema_description:"Number description"`
 		}
 
-		req := llmadapter.NewRequest[Format]()
+		req := llmberjack.NewRequest[Format]()
 
 		cfg, err := p.adaptRequest(llm, req)
 
@@ -131,7 +131,7 @@ func TestRequestAdapter(t *testing.T) {
 	})
 
 	t.Run("with request options", func(t *testing.T) {
-		req := llmadapter.NewUntypedRequest().
+		req := llmberjack.NewUntypedRequest().
 			WithMaxCandidates(10).
 			WithMaxTokens(42).
 			WithTemperature(0.1).

--- a/llms/openai/openai_test.go
+++ b/llms/openai/openai_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
-	"github.com/checkmarble/llm-adapter/llms/openai"
+	llmberjack "github.com/checkmarble/llmberjack"
+	"github.com/checkmarble/llmberjack/llms/openai"
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
@@ -43,17 +43,17 @@ func TestOpenAiRequest(t *testing.T) {
 	}
 
 	provider, _ := openai.New(openai.WithApiKey("apikey"))
-	llm, _ := llmadapter.New(llmadapter.WithDefaultProvider(provider))
+	llm, _ := llmberjack.New(llmberjack.WithDefaultProvider(provider))
 
-	req := llmadapter.NewRequest[Output]().
+	req := llmberjack.NewRequest[Output]().
 		WithModel("themodel").
 		WithInstruction("system text").
 		WithInstructionReader(strings.NewReader("text from reader")).
-		WithText(llmadapter.RoleUser, "user text").
-		WithTools(llmadapter.NewTool[Args]("thetool", "Tool to get nothing", llmadapter.Function(func(Args) (string, error) {
+		WithText(llmberjack.RoleUser, "user text").
+		WithTools(llmberjack.NewTool[Args]("thetool", "Tool to get nothing", llmberjack.Function(func(Args) (string, error) {
 			return "OK", nil
 		}))).
-		WithTextReader(llmadapter.RoleUser, strings.NewReader("text from reader"))
+		WithTextReader(llmberjack.RoleUser, strings.NewReader("text from reader"))
 
 	gock.New("https://api.openai.com").
 		Post("/v1/chat/completions").
@@ -104,7 +104,7 @@ func TestOpenAiRequest(t *testing.T) {
 	candidate, err := resp.Candidate(0)
 
 	assert.Nil(t, err)
-	assert.Equal(t, llmadapter.FinishReasonStop, candidate.FinishReason)
+	assert.Equal(t, llmberjack.FinishReasonStop, candidate.FinishReason)
 
 	output, err := resp.Get(0)
 

--- a/llms/perplexity/perplexity.go
+++ b/llms/perplexity/perplexity.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"time"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
-	"github.com/checkmarble/llm-adapter/internal"
-	base "github.com/checkmarble/llm-adapter/llms/openai"
+	llmberjack "github.com/checkmarble/llmberjack"
+	"github.com/checkmarble/llmberjack/internal"
+	base "github.com/checkmarble/llmberjack/llms/openai"
 	"github.com/fatih/structs"
 	"github.com/openai/openai-go"
 	"github.com/samber/lo"
@@ -44,7 +44,7 @@ func New(openAiOpts ...base.Opt) (*Perplexity, error) {
 	return &llm, nil
 }
 
-func (p *Perplexity) transformRequest(requester llmadapter.Requester, cfg *openai.ChatCompletionNewParams) error {
+func (p *Perplexity) transformRequest(requester llmberjack.Requester, cfg *openai.ChatCompletionNewParams) error {
 	opts := internal.CastProviderOptions[RequestOptions](requester.ProviderRequestOptions(p))
 
 	cfg.SetExtraFields(structs.Map(opts))
@@ -52,7 +52,7 @@ func (p *Perplexity) transformRequest(requester llmadapter.Requester, cfg *opena
 	return nil
 }
 
-func (p *Perplexity) transformResponse(response *openai.ChatCompletion, resp *llmadapter.InnerResponse) error {
+func (p *Perplexity) transformResponse(response *openai.ChatCompletion, resp *llmberjack.InnerResponse) error {
 	searchResultsField, ok := response.JSON.ExtraFields["search_results"]
 	if !ok {
 		return nil
@@ -70,11 +70,11 @@ func (p *Perplexity) transformResponse(response *openai.ChatCompletion, resp *ll
 	// Perplexity returns only one candidate, the search results are linked to this candidate
 	// Use loop to avoid dealing with checking if there is a candidate or not
 	for i := range resp.Candidates {
-		grounding := llmadapter.ResponseGrounding{
-			Sources: lo.Map(searchResults, func(result SearchResult, _ int) llmadapter.ResponseGroundingSource {
+		grounding := llmberjack.ResponseGrounding{
+			Sources: lo.Map(searchResults, func(result SearchResult, _ int) llmberjack.ResponseGroundingSource {
 				date, _ := time.Parse(time.DateOnly, result.Date)
 
-				return llmadapter.ResponseGroundingSource{
+				return llmberjack.ResponseGroundingSource{
 					Title: result.Title,
 					Url:   result.URL,
 					Date:  date,

--- a/llms/perplexity/perplexity_test.go
+++ b/llms/perplexity/perplexity_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
-	"github.com/checkmarble/llm-adapter/llms/openai"
+	llmberjack "github.com/checkmarble/llmberjack"
+	"github.com/checkmarble/llmberjack/llms/openai"
 	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
 	"github.com/tidwall/gjson"
@@ -17,9 +17,9 @@ func TestPerplexityExtras(t *testing.T) {
 	defer gock.Off()
 
 	provider, _ := New(openai.WithApiKey("apikey"))
-	llm, _ := llmadapter.New(llmadapter.WithDefaultProvider(provider))
+	llm, _ := llmberjack.New(llmberjack.WithDefaultProvider(provider))
 
-	req := llmadapter.NewUntypedRequest().
+	req := llmberjack.NewUntypedRequest().
 		WithProviderOptions(RequestOptions{
 			SearchMode: SearchModeAcademic,
 			BeforeDate: NewDate(time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC)),
@@ -28,7 +28,7 @@ func TestPerplexityExtras(t *testing.T) {
 			},
 			SearchDomainFilter: []string{"google.com", "wikipedia.org"},
 		}).
-		WithText(llmadapter.RoleUser, "C'est une bonne situation ça Scribe ?")
+		WithText(llmberjack.RoleUser, "C'est une bonne situation ça Scribe ?")
 
 	gock.New("https://api.perplexity.ai").
 		Post("/chat/completions").

--- a/mock_provider_test.go
+++ b/mock_provider_test.go
@@ -1,11 +1,11 @@
-package llmadapter
+package llmberjack
 
 import (
 	"context"
 	"io"
 	"reflect"
 
-	"github.com/checkmarble/llm-adapter/internal"
+	"github.com/checkmarble/llmberjack/internal"
 	"github.com/stretchr/testify/mock"
 )
 

--- a/options.go
+++ b/options.go
@@ -1,12 +1,12 @@
-package llmadapter
+package llmberjack
 
 import "net/http"
 
-type llmOption func(*LlmAdapter)
+type llmOption func(*llmberjack)
 
 // WithDefaultProvider sets what LLM provider to use for communication.
 func WithDefaultProvider(provider Llm) llmOption {
-	return func(llm *LlmAdapter) {
+	return func(llm *llmberjack) {
 		llm.providers[defaultProvider] = provider
 		llm.defaultProvider = llm.providers[defaultProvider]
 	}
@@ -17,7 +17,7 @@ func WithDefaultProvider(provider Llm) llmOption {
 // The first one to be registered will become the default, unless a default was
 // already or is defined later with `SetDefaultProvider`.
 func WithProvider(name string, provider Llm) llmOption {
-	return func(llm *LlmAdapter) {
+	return func(llm *llmberjack) {
 		llm.providers[name] = provider
 
 		if llm.defaultProvider == nil {
@@ -31,7 +31,7 @@ func WithProvider(name string, provider Llm) llmOption {
 // request. It is the caller's responsibility to ensure the requested model is
 // available on the configured provider.
 func WithDefaultModel(model string) llmOption {
-	return func(llm *LlmAdapter) {
+	return func(llm *llmberjack) {
 		llm.defaultModel = model
 	}
 }
@@ -41,7 +41,7 @@ func WithDefaultModel(model string) llmOption {
 // If a provider does not support overriding the HTTP client, this will be
 // ignored.
 func WithHttpClient(client *http.Client) llmOption {
-	return func(llm *LlmAdapter) {
+	return func(llm *llmberjack) {
 		llm.httpClient = client
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"net/http"

--- a/request.go
+++ b/request.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"bytes"
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/checkmarble/llm-adapter/internal"
+	"github.com/checkmarble/llmberjack/internal"
 	"github.com/cockroachdb/errors"
 	"github.com/invopop/jsonschema"
 	"github.com/samber/lo"
@@ -124,8 +124,8 @@ func NewUntypedRequest() Request[string] {
 //
 // Example usage:
 //
-//	resp, err := llmadapter.NewRequest[Output]().
-//		WithText(llmadapter.RoleUser, "How are you today?").
+//	resp, err := llmberjack.NewRequest[Output]().
+//		WithText(llmberjack.RoleUser, "How are you today?").
 //		Do(ctx, llm)
 func NewRequest[T any]() Request[T] {
 	r := innerRequest{
@@ -148,7 +148,7 @@ func NewRequest[T any]() Request[T] {
 //
 // It will return a response generic over the configured typed on the Request,
 // or an error.
-func (r Request[T]) Do(ctx context.Context, llm *LlmAdapter) (*Response[T], error) {
+func (r Request[T]) Do(ctx context.Context, llm *llmberjack) (*Response[T], error) {
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -217,9 +217,9 @@ func (r Request[T]) InThread(threadId *ThreadId) Request[T] {
 //
 // Example usage:
 //
-//	resp, err := llmadapter.NewRequest[Output]().
+//	resp, err := llmberjack.NewRequest[Output]().
 //		FromCandidate(previousResp, 0).
-//		WithText(llmadapter.RoleUser, "How are you today?").
+//		WithText(llmberjack.RoleUser, "How are you today?").
 //		Do(ctx, llm)
 func (r Request[T]) FromCandidate(c Candidater, idx int) Request[T] {
 	r.ThreadId = c.Thread()
@@ -390,9 +390,9 @@ func (r Request[T]) OverrideResponseSchema(schema jsonschema.Schema) Request[T] 
 //
 // Example usage:
 //
-//	resp, err := llmadapter.NewRequest[Output]().
-//		WithText(llmadapter.RoleUser, "How are you today?").
-//		WithTool(llmadapter.NewTool[WeatherParams]("get_weather", "Get weather at location", llmadapter.Function(func(args WeatherParams) (string, error) {
+//	resp, err := llmberjack.NewRequest[Output]().
+//		WithText(llmberjack.RoleUser, "How are you today?").
+//		WithTool(llmberjack.NewTool[WeatherParams]("get_weather", "Get weather at location", llmberjack.Function(func(args WeatherParams) (string, error) {
 //			return "Good weather!", nil
 //		})).
 //		Do(ctx, llm)

--- a/request_test.go
+++ b/request_test.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"io"

--- a/response.go
+++ b/response.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"encoding/json"

--- a/response_test.go
+++ b/response_test.go
@@ -1,9 +1,9 @@
-package llmadapter_test
+package llmberjack_test
 
 import (
 	"testing"
 
-	llmadapter "github.com/checkmarble/llm-adapter"
+	llmberjack "github.com/checkmarble/llmberjack"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,9 +12,9 @@ func TestResponseGetOutput(t *testing.T) {
 		Text string `json:"text"`
 	}
 
-	r := llmadapter.Response[output]{
-		InnerResponse: llmadapter.InnerResponse{
-			Candidates: []llmadapter.ResponseCandidate{
+	r := llmberjack.Response[output]{
+		InnerResponse: llmberjack.InnerResponse{
+			Candidates: []llmberjack.ResponseCandidate{
 				{Text: `{"text":"first response"}`},
 				{Text: `{"text":"second response"}`},
 			},
@@ -43,9 +43,9 @@ func TestResponseGetInvalidJson(t *testing.T) {
 		Text string `json:"text"`
 	}
 
-	r := llmadapter.Response[output]{
-		InnerResponse: llmadapter.InnerResponse{
-			Candidates: []llmadapter.ResponseCandidate{
+	r := llmberjack.Response[output]{
+		InnerResponse: llmberjack.InnerResponse{
+			Candidates: []llmberjack.ResponseCandidate{
 				{Text: `{"text":"first`},
 			},
 		},
@@ -59,9 +59,9 @@ func TestResponseGetInvalidJson(t *testing.T) {
 }
 
 func TestResponseGetStringOutput(t *testing.T) {
-	r := llmadapter.Response[string]{
-		InnerResponse: llmadapter.InnerResponse{
-			Candidates: []llmadapter.ResponseCandidate{
+	r := llmberjack.Response[string]{
+		InnerResponse: llmberjack.InnerResponse{
+			Candidates: []llmberjack.ResponseCandidate{
 				{Text: "first response"},
 				{Text: "second response"},
 			},
@@ -90,9 +90,9 @@ func TestResponseGetCandidate(t *testing.T) {
 		Text string `json:"text"`
 	}
 
-	r := llmadapter.Response[output]{
-		InnerResponse: llmadapter.InnerResponse{
-			Candidates: []llmadapter.ResponseCandidate{
+	r := llmberjack.Response[output]{
+		InnerResponse: llmberjack.InnerResponse{
+			Candidates: []llmberjack.ResponseCandidate{
 				{Text: `{"text":"first response"}`},
 				{Text: `{"text":"second response"}`},
 			},

--- a/serializer.go
+++ b/serializer.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"encoding/csv"

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"io"

--- a/sync.go
+++ b/sync.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"context"
@@ -12,7 +12,7 @@ type AsyncResponse[T any] struct {
 	Error    error
 }
 
-func All[T any](ctx context.Context, llm *LlmAdapter, reqs ...Request[T]) []AsyncResponse[T] {
+func All[T any](ctx context.Context, llm *llmberjack, reqs ...Request[T]) []AsyncResponse[T] {
 	var wg sync.WaitGroup
 
 	responses := make([]AsyncResponse[T], len(reqs))
@@ -38,7 +38,7 @@ func All[T any](ctx context.Context, llm *LlmAdapter, reqs ...Request[T]) []Asyn
 	return responses
 }
 
-func Race[T any](ctx context.Context, llm *LlmAdapter, reqs ...Request[T]) (*Response[T], error) {
+func Race[T any](ctx context.Context, llm *llmberjack, reqs ...Request[T]) (*Response[T], error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/sync_test.go
+++ b/sync_test.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"testing"

--- a/threads.go
+++ b/threads.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 type noCopy struct{}
 

--- a/tools.go
+++ b/tools.go
@@ -1,7 +1,7 @@
-package llmadapter
+package llmberjack
 
 import (
-	"github.com/checkmarble/llm-adapter/internal"
+	"github.com/checkmarble/llmberjack/internal"
 )
 
 // Function is a wrapper for the code executed in a tool.

--- a/tools_test.go
+++ b/tools_test.go
@@ -1,4 +1,4 @@
-package llmadapter
+package llmberjack
 
 import (
 	"io"


### PR DESCRIPTION
This pull request performs a comprehensive package rename from `llmadapter` to `llmberjack` throughout the codebase and documentation. The changes ensure that all references, identifiers, and import paths now use the new package name, maintaining consistency and avoiding confusion. No functional code changes are introduced; the update is strictly renaming for branding or organizational purposes.