### PR TITLE
fix: update struct name from llmberjack to Llmberjack

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ output, err := resp.Get(0)
 
 A few utilities are available to run multiple requests at the same time:
 
- - `llmberjack.All[T](context.Context, *llmberjack.llmberjack, reqs ...Request[T])` can be used to fire several requests at once, wait for all of them to return and get a slice of results.
- - `llmberjack.Race[T](context.Context, *llmberjack.llmberjack, reqs ...Request[T])` can be used to fire several requests at once, return the first successful response, and cancel the others.
+ - `llmberjack.All[T](context.Context, *llmberjack.Llmberjack, reqs ...Request[T])` can be used to fire several requests at once, wait for all of them to return and get a slice of results.
+ - `llmberjack.Race[T](context.Context, *llmberjack.Llmberjack, reqs ...Request[T])` can be used to fire several requests at once, return the first successful response, and cancel the others.
 
 Note that cancelled requests will still incur cost on most providers.
 

--- a/adapter.go
+++ b/adapter.go
@@ -37,9 +37,9 @@ type Llm interface {
 	RequestOptionsType() reflect.Type
 }
 
-// llmberjack is the main entrypoint for interacting with different LLM providers.
+// Llmberjack is the main entrypoint for interacting with different LLM providers.
 // It provides a unified interface to send requests and receive responses.
-type llmberjack struct {
+type Llmberjack struct {
 	providers       map[string]Llm
 	defaultProvider Llm
 
@@ -47,7 +47,7 @@ type llmberjack struct {
 	defaultModel string
 }
 
-// New creates a new llmberjack with the given options.
+// New creates a new Llmberjack with the given options.
 // It initializes the specified LLM provider and returns a configured adapter.
 //
 // Example usage:
@@ -57,8 +57,8 @@ type llmberjack struct {
 //		llmberjack.WithDefaultModel("gpt-4"),
 //		llmberjack.WithApiKey("...")
 //	)
-func New(opts ...llmOption) (*llmberjack, error) {
-	llm := llmberjack{
+func New(opts ...llmOption) (*Llmberjack, error) {
+	llm := Llmberjack{
 		providers: make(map[string]Llm),
 	}
 
@@ -80,7 +80,7 @@ func New(opts ...llmOption) (*llmberjack, error) {
 // new adapter instance. This also clears the systems instructions.
 // If called without arguments, will clear the history of the default provider,
 // otherwise, it accepts variadic provider names for which to clear the history.
-// func (llm *llmberjack) ResetThreads(threadIds ...*ThreadId) {
+// func (llm *Llmberjack) ResetThreads(threadIds ...*ThreadId) {
 // 	for _, thread := range threadIds {
 // 		thread.provider.ResetThread(thread)
 // 	}
@@ -90,7 +90,7 @@ func New(opts ...llmOption) (*llmberjack, error) {
 // It accepts the provider requested in a specific request, which will override
 // the default provider. If the provider argument is nil, it will return the
 // configured default provider.
-func (llm *llmberjack) GetProvider(requestProvider *string) (Llm, error) {
+func (llm *Llmberjack) GetProvider(requestProvider *string) (Llm, error) {
 	if llm.defaultProvider == nil {
 		return nil, errors.New("no provider was configured")
 	}
@@ -109,12 +109,12 @@ func (llm *llmberjack) GetProvider(requestProvider *string) (Llm, error) {
 	return provider, nil
 }
 
-// llmberjack implementation of Adapter
+// Llmberjack implementation of Adapter
 
-func (llm llmberjack) DefaultModel() string {
+func (llm Llmberjack) DefaultModel() string {
 	return llm.defaultModel
 }
 
-func (llm llmberjack) HttpClient() *http.Client {
+func (llm Llmberjack) HttpClient() *http.Client {
 	return llm.httpClient
 }

--- a/options.go
+++ b/options.go
@@ -2,11 +2,11 @@ package llmberjack
 
 import "net/http"
 
-type llmOption func(*llmberjack)
+type llmOption func(*Llmberjack)
 
 // WithDefaultProvider sets what LLM provider to use for communication.
 func WithDefaultProvider(provider Llm) llmOption {
-	return func(llm *llmberjack) {
+	return func(llm *Llmberjack) {
 		llm.providers[defaultProvider] = provider
 		llm.defaultProvider = llm.providers[defaultProvider]
 	}
@@ -17,7 +17,7 @@ func WithDefaultProvider(provider Llm) llmOption {
 // The first one to be registered will become the default, unless a default was
 // already or is defined later with `SetDefaultProvider`.
 func WithProvider(name string, provider Llm) llmOption {
-	return func(llm *llmberjack) {
+	return func(llm *Llmberjack) {
 		llm.providers[name] = provider
 
 		if llm.defaultProvider == nil {
@@ -31,7 +31,7 @@ func WithProvider(name string, provider Llm) llmOption {
 // request. It is the caller's responsibility to ensure the requested model is
 // available on the configured provider.
 func WithDefaultModel(model string) llmOption {
-	return func(llm *llmberjack) {
+	return func(llm *Llmberjack) {
 		llm.defaultModel = model
 	}
 }
@@ -41,7 +41,7 @@ func WithDefaultModel(model string) llmOption {
 // If a provider does not support overriding the HTTP client, this will be
 // ignored.
 func WithHttpClient(client *http.Client) llmOption {
-	return func(llm *llmberjack) {
+	return func(llm *Llmberjack) {
 		llm.httpClient = client
 	}
 }

--- a/request.go
+++ b/request.go
@@ -148,7 +148,7 @@ func NewRequest[T any]() Request[T] {
 //
 // It will return a response generic over the configured typed on the Request,
 // or an error.
-func (r Request[T]) Do(ctx context.Context, llm *llmberjack) (*Response[T], error) {
+func (r Request[T]) Do(ctx context.Context, llm *Llmberjack) (*Response[T], error) {
 	if r.err != nil {
 		return nil, r.err
 	}

--- a/sync.go
+++ b/sync.go
@@ -12,7 +12,7 @@ type AsyncResponse[T any] struct {
 	Error    error
 }
 
-func All[T any](ctx context.Context, llm *llmberjack, reqs ...Request[T]) []AsyncResponse[T] {
+func All[T any](ctx context.Context, llm *Llmberjack, reqs ...Request[T]) []AsyncResponse[T] {
 	var wg sync.WaitGroup
 
 	responses := make([]AsyncResponse[T], len(reqs))
@@ -38,7 +38,7 @@ func All[T any](ctx context.Context, llm *llmberjack, reqs ...Request[T]) []Asyn
 	return responses
 }
 
-func Race[T any](ctx context.Context, llm *llmberjack, reqs ...Request[T]) (*Response[T], error) {
+func Race[T any](ctx context.Context, llm *Llmberjack, reqs ...Request[T]) (*Response[T], error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 


### PR DESCRIPTION
This pull request refactors the codebase to standardize the naming of the main adapter type from `llmberjack` to `Llmberjack`. This change improves consistency and clarity throughout the project, affecting type definitions, function signatures, and documentation. All references to the main adapter are updated to use the new name, ensuring uniformity across files and usage patterns.