### PR TITLE
fix!: Rename Llmberjack by LlmAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ output, err := resp.Get(0)
 
 A few utilities are available to run multiple requests at the same time:
 
- - `llmberjack.All[T](context.Context, *llmberjack.Llmberjack, reqs ...Request[T])` can be used to fire several requests at once, wait for all of them to return and get a slice of results.
- - `llmberjack.Race[T](context.Context, *llmberjack.Llmberjack, reqs ...Request[T])` can be used to fire several requests at once, return the first successful response, and cancel the others.
+ - `llmberjack.All[T](context.Context, *llmberjack.LlmAdapter, reqs ...Request[T])` can be used to fire several requests at once, wait for all of them to return and get a slice of results.
+ - `llmberjack.Race[T](context.Context, *llmberjack.LlmAdapter, reqs ...Request[T])` can be used to fire several requests at once, return the first successful response, and cancel the others.
 
 Note that cancelled requests will still incur cost on most providers.
 

--- a/adapter.go
+++ b/adapter.go
@@ -37,9 +37,9 @@ type Llm interface {
 	RequestOptionsType() reflect.Type
 }
 
-// Llmberjack is the main entrypoint for interacting with different LLM providers.
+// LlmAdapter is the main entrypoint for interacting with different LLM providers.
 // It provides a unified interface to send requests and receive responses.
-type Llmberjack struct {
+type LlmAdapter struct {
 	providers       map[string]Llm
 	defaultProvider Llm
 
@@ -47,7 +47,7 @@ type Llmberjack struct {
 	defaultModel string
 }
 
-// New creates a new Llmberjack with the given options.
+// New creates a new LlmAdapter with the given options.
 // It initializes the specified LLM provider and returns a configured adapter.
 //
 // Example usage:
@@ -57,8 +57,8 @@ type Llmberjack struct {
 //		llmberjack.WithDefaultModel("gpt-4"),
 //		llmberjack.WithApiKey("...")
 //	)
-func New(opts ...llmOption) (*Llmberjack, error) {
-	llm := Llmberjack{
+func New(opts ...llmOption) (*LlmAdapter, error) {
+	llm := LlmAdapter{
 		providers: make(map[string]Llm),
 	}
 
@@ -80,7 +80,7 @@ func New(opts ...llmOption) (*Llmberjack, error) {
 // new adapter instance. This also clears the systems instructions.
 // If called without arguments, will clear the history of the default provider,
 // otherwise, it accepts variadic provider names for which to clear the history.
-// func (llm *Llmberjack) ResetThreads(threadIds ...*ThreadId) {
+// func (llm *LlmAdapter) ResetThreads(threadIds ...*ThreadId) {
 // 	for _, thread := range threadIds {
 // 		thread.provider.ResetThread(thread)
 // 	}
@@ -90,7 +90,7 @@ func New(opts ...llmOption) (*Llmberjack, error) {
 // It accepts the provider requested in a specific request, which will override
 // the default provider. If the provider argument is nil, it will return the
 // configured default provider.
-func (llm *Llmberjack) GetProvider(requestProvider *string) (Llm, error) {
+func (llm *LlmAdapter) GetProvider(requestProvider *string) (Llm, error) {
 	if llm.defaultProvider == nil {
 		return nil, errors.New("no provider was configured")
 	}
@@ -109,12 +109,12 @@ func (llm *Llmberjack) GetProvider(requestProvider *string) (Llm, error) {
 	return provider, nil
 }
 
-// Llmberjack implementation of Adapter
+// LlmAdapter implementation of Adapter
 
-func (llm Llmberjack) DefaultModel() string {
+func (llm LlmAdapter) DefaultModel() string {
 	return llm.defaultModel
 }
 
-func (llm Llmberjack) HttpClient() *http.Client {
+func (llm LlmAdapter) HttpClient() *http.Client {
 	return llm.httpClient
 }

--- a/options.go
+++ b/options.go
@@ -2,11 +2,11 @@ package llmberjack
 
 import "net/http"
 
-type llmOption func(*Llmberjack)
+type llmOption func(*LlmAdapter)
 
 // WithDefaultProvider sets what LLM provider to use for communication.
 func WithDefaultProvider(provider Llm) llmOption {
-	return func(llm *Llmberjack) {
+	return func(llm *LlmAdapter) {
 		llm.providers[defaultProvider] = provider
 		llm.defaultProvider = llm.providers[defaultProvider]
 	}
@@ -17,7 +17,7 @@ func WithDefaultProvider(provider Llm) llmOption {
 // The first one to be registered will become the default, unless a default was
 // already or is defined later with `SetDefaultProvider`.
 func WithProvider(name string, provider Llm) llmOption {
-	return func(llm *Llmberjack) {
+	return func(llm *LlmAdapter) {
 		llm.providers[name] = provider
 
 		if llm.defaultProvider == nil {
@@ -31,7 +31,7 @@ func WithProvider(name string, provider Llm) llmOption {
 // request. It is the caller's responsibility to ensure the requested model is
 // available on the configured provider.
 func WithDefaultModel(model string) llmOption {
-	return func(llm *Llmberjack) {
+	return func(llm *LlmAdapter) {
 		llm.defaultModel = model
 	}
 }
@@ -41,7 +41,7 @@ func WithDefaultModel(model string) llmOption {
 // If a provider does not support overriding the HTTP client, this will be
 // ignored.
 func WithHttpClient(client *http.Client) llmOption {
-	return func(llm *Llmberjack) {
+	return func(llm *LlmAdapter) {
 		llm.httpClient = client
 	}
 }

--- a/request.go
+++ b/request.go
@@ -148,7 +148,7 @@ func NewRequest[T any]() Request[T] {
 //
 // It will return a response generic over the configured typed on the Request,
 // or an error.
-func (r Request[T]) Do(ctx context.Context, llm *Llmberjack) (*Response[T], error) {
+func (r Request[T]) Do(ctx context.Context, llm *LlmAdapter) (*Response[T], error) {
 	if r.err != nil {
 		return nil, r.err
 	}

--- a/sync.go
+++ b/sync.go
@@ -12,7 +12,7 @@ type AsyncResponse[T any] struct {
 	Error    error
 }
 
-func All[T any](ctx context.Context, llm *Llmberjack, reqs ...Request[T]) []AsyncResponse[T] {
+func All[T any](ctx context.Context, llm *LlmAdapter, reqs ...Request[T]) []AsyncResponse[T] {
 	var wg sync.WaitGroup
 
 	responses := make([]AsyncResponse[T], len(reqs))
@@ -38,7 +38,7 @@ func All[T any](ctx context.Context, llm *Llmberjack, reqs ...Request[T]) []Asyn
 	return responses
 }
 
-func Race[T any](ctx context.Context, llm *Llmberjack, reqs ...Request[T]) (*Response[T], error) {
+func Race[T any](ctx context.Context, llm *LlmAdapter, reqs ...Request[T]) (*Response[T], error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 


### PR DESCRIPTION
This pull request refactors the codebase to rename the main adapter type for interacting with LLM providers from `Llmberjack` to `LlmAdapter`. The change is applied consistently across all relevant files, including the type definition, constructor, method receivers, options, and usage in utility functions. This update improves clarity and better reflects the purpose of the type.

### Major Type Renaming

* Renamed the main adapter type from `Llmberjack` to `LlmAdapter` throughout the codebase, including its struct definition, constructor, and method receivers in `adapter.go`. [[1]](diffhunk://#diff-c5d420087ebe146b0024e82a914f630f79dc68b2f257bdfd9f0972eb584841b3L40-R50) [[2]](diffhunk://#diff-c5d420087ebe146b0024e82a914f630f79dc68b2f257bdfd9f0972eb584841b3L60-R61) [[3]](diffhunk://#diff-c5d420087ebe146b0024e82a914f630f79dc68b2f257bdfd9f0972eb584841b3L83-R83) [[4]](diffhunk://#diff-c5d420087ebe146b0024e82a914f630f79dc68b2f257bdfd9f0972eb584841b3L93-R93) [[5]](diffhunk://#diff-c5d420087ebe146b0024e82a914f630f79dc68b2f257bdfd9f0972eb584841b3L112-R118)

### Updates to Utility Functions and Options

* Updated all utility functions (`All`, `Race`) and request execution to accept `*LlmAdapter` instead of `*Llmberjack`, in `sync.go` and `request.go`. [[1]](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeL15-R15) [[2]](diffhunk://#diff-d41679517cfd690d16b66f15bf8af782a50081525eb9df1af20ccc8f10d092aeL41-R41) [[3]](diffhunk://#diff-3c2feffcf57ffb6c596dc5608186c518252092b7017be5189d3dc12aa3c45cecL151-R151)
* Changed all option functions (`WithDefaultProvider`, `WithProvider`, `WithDefaultModel`, `WithHttpClient`) to use `*LlmAdapter` in `options.go`. [[1]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L5-R9) [[2]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L20-R20) [[3]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L34-R34) [[4]](diffhunk://#diff-4eec45b6a922746411c0f8aea183e30f77af1b0a5bea1688eaf343a5f9c23703L44-R44)

### Documentation Updates

* Updated documentation and usage examples in `README.md` to reference `LlmAdapter` instead of `Llmberjack`.