### PR TITLE
feat(ai_studio): add thinking configuration in request Options

### DIFF
--- a/internal/types.go
+++ b/internal/types.go
@@ -23,3 +23,11 @@ func MaybeF64ToF32(f *float64) *float32 {
 
 	return lo.ToPtr(float32(*f))
 }
+
+func MaybeIntToInt32(i *int) *int32 {
+	if i == nil {
+		return nil
+	}
+
+	return lo.ToPtr(int32(*i))
+}

--- a/llms/aistudio/aistudio.go
+++ b/llms/aistudio/aistudio.go
@@ -122,10 +122,16 @@ func (p *AiStudio) adaptRequest(_ internal.Adapter, requester llmberjack.Request
 		}}
 	}
 
-	if opts.Thinking != nil {
+	if r.Thinking != nil && !lo.FromPtr(r.Thinking) {
 		cfg.ThinkingConfig = &genai.ThinkingConfig{
-			IncludeThoughts: opts.Thinking.IncludeThoughts,
-			ThinkingBudget:  internal.MaybeIntToInt32(opts.Thinking.Budget),
+			ThinkingBudget: internal.MaybeIntToInt32(lo.ToPtr(int(0))),
+		}
+	} else {
+		if opts.Thinking != nil {
+			cfg.ThinkingConfig = &genai.ThinkingConfig{
+				IncludeThoughts: opts.Thinking.IncludeThoughts,
+				ThinkingBudget:  internal.MaybeIntToInt32(opts.Thinking.Budget),
+			}
 		}
 	}
 

--- a/llms/aistudio/aistudio.go
+++ b/llms/aistudio/aistudio.go
@@ -122,6 +122,13 @@ func (p *AiStudio) adaptRequest(_ internal.Adapter, requester llmberjack.Request
 		}}
 	}
 
+	if opts.Thinking != nil {
+		cfg.ThinkingConfig = &genai.ThinkingConfig{
+			IncludeThoughts: opts.Thinking.IncludeThoughts,
+			ThinkingBudget:  opts.Thinking.Budget,
+		}
+	}
+
 	if r.ResponseSchema != nil {
 		r.ResponseSchema.Description = r.SchemaDescription
 

--- a/llms/aistudio/aistudio.go
+++ b/llms/aistudio/aistudio.go
@@ -124,7 +124,7 @@ func (p *AiStudio) adaptRequest(_ internal.Adapter, requester llmberjack.Request
 
 	if r.Thinking != nil && !lo.FromPtr(r.Thinking) {
 		cfg.ThinkingConfig = &genai.ThinkingConfig{
-			ThinkingBudget: internal.MaybeIntToInt32(lo.ToPtr(int(0))),
+			ThinkingBudget: lo.ToPtr(int32(0)),
 		}
 	} else {
 		if opts.Thinking != nil {

--- a/llms/aistudio/aistudio.go
+++ b/llms/aistudio/aistudio.go
@@ -125,7 +125,7 @@ func (p *AiStudio) adaptRequest(_ internal.Adapter, requester llmberjack.Request
 	if opts.Thinking != nil {
 		cfg.ThinkingConfig = &genai.ThinkingConfig{
 			IncludeThoughts: opts.Thinking.IncludeThoughts,
-			ThinkingBudget:  opts.Thinking.Budget,
+			ThinkingBudget:  internal.MaybeIntToInt32(opts.Thinking.Budget),
 		}
 	}
 

--- a/llms/aistudio/aistudio_test.go
+++ b/llms/aistudio/aistudio_test.go
@@ -162,7 +162,7 @@ func TestGoogleAiRequestWithThinking(t *testing.T) {
 			thinking: nil,
 			requestOptions: &aistudio.RequestOptions{
 				Thinking: &aistudio.ThinkingConfig{
-					Budget: lo.ToPtr(int(50)),
+					Budget: lo.ToPtr(50),
 				},
 			},
 			expectedMatcher: func(body []byte) bool {
@@ -177,7 +177,7 @@ func TestGoogleAiRequestWithThinking(t *testing.T) {
 			requestOptions: &aistudio.RequestOptions{
 				Thinking: &aistudio.ThinkingConfig{
 					IncludeThoughts: true,
-					Budget:          lo.ToPtr(int(100)),
+					Budget:          lo.ToPtr(100),
 				},
 			},
 			expectedMatcher: func(body []byte) bool {
@@ -190,7 +190,7 @@ func TestGoogleAiRequestWithThinking(t *testing.T) {
 			name: "With requestOption - Disable thinking",
 			requestOptions: &aistudio.RequestOptions{
 				Thinking: &aistudio.ThinkingConfig{
-					Budget: lo.ToPtr(int(0)),
+					Budget: lo.ToPtr(0),
 				},
 			},
 			expectedMatcher: func(body []byte) bool {
@@ -216,7 +216,7 @@ func TestGoogleAiRequestWithThinking(t *testing.T) {
 			thinking: lo.ToPtr(false),
 			requestOptions: &aistudio.RequestOptions{
 				Thinking: &aistudio.ThinkingConfig{
-					Budget: lo.ToPtr(int(100)),
+					Budget: lo.ToPtr(100),
 				},
 			},
 			expectedMatcher: func(body []byte) bool {
@@ -242,7 +242,7 @@ func TestGoogleAiRequestWithThinking(t *testing.T) {
 			requestOptions: &aistudio.RequestOptions{
 				Thinking: &aistudio.ThinkingConfig{
 					IncludeThoughts: true,
-					Budget:          lo.ToPtr(int(100)),
+					Budget:          lo.ToPtr(100),
 				},
 			},
 			expectedMatcher: func(body []byte) bool {

--- a/llms/aistudio/aistudio_test.go
+++ b/llms/aistudio/aistudio_test.go
@@ -158,7 +158,7 @@ func TestGoogleAiRequestWithThinking(t *testing.T) {
 			name: "With requestOption - only Budget",
 			requestOptions: &aistudio.RequestOptions{
 				Thinking: &aistudio.ThinkingConfig{
-					Budget: lo.ToPtr(int32(50)),
+					Budget: lo.ToPtr(int(50)),
 				},
 			},
 			expectedMatcher: func(body []byte) bool {
@@ -172,7 +172,7 @@ func TestGoogleAiRequestWithThinking(t *testing.T) {
 			requestOptions: &aistudio.RequestOptions{
 				Thinking: &aistudio.ThinkingConfig{
 					IncludeThoughts: true,
-					Budget:          lo.ToPtr(int32(100)),
+					Budget:          lo.ToPtr(int(100)),
 				},
 			},
 			expectedMatcher: func(body []byte) bool {
@@ -185,7 +185,7 @@ func TestGoogleAiRequestWithThinking(t *testing.T) {
 			name: "With requestOption - Disable thinking",
 			requestOptions: &aistudio.RequestOptions{
 				Thinking: &aistudio.ThinkingConfig{
-					Budget: lo.ToPtr(int32(0)),
+					Budget: lo.ToPtr(int(0)),
 				},
 			},
 			expectedMatcher: func(body []byte) bool {

--- a/llms/aistudio/request_options.go
+++ b/llms/aistudio/request_options.go
@@ -1,8 +1,16 @@
 package aistudio
 
+type ThinkingConfig struct {
+	IncludeThoughts bool
+	// To disable thinking, set the budget to 0
+	// cf: https://cloud.google.com/vertex-ai/generative-ai/docs/thinking#budget
+	Budget *int32
+}
+
 type RequestOptions struct {
 	GoogleSearch *bool
 	TopK         *float64
+	Thinking     *ThinkingConfig
 }
 
 func (RequestOptions) ProviderRequestOptions() {}

--- a/llms/aistudio/request_options.go
+++ b/llms/aistudio/request_options.go
@@ -4,7 +4,7 @@ type ThinkingConfig struct {
 	IncludeThoughts bool
 	// To disable thinking, set the budget to 0
 	// cf: https://cloud.google.com/vertex-ai/generative-ai/docs/thinking#budget
-	Budget *int32
+	Budget *int
 }
 
 type RequestOptions struct {

--- a/request.go
+++ b/request.go
@@ -81,6 +81,9 @@ type innerRequest struct {
 	Temperature   *float64
 	TopP          *float64
 
+	// Thinking is a flag to enable/disable thinking. If not provided, the provider will use its default behavior.
+	Thinking *bool
+
 	ProviderOptions map[reflect.Type]internal.ProviderRequestOptions
 }
 
@@ -497,6 +500,12 @@ func (r Request[T]) WithTemperature(temp float64) Request[T] {
 // WithTopP sets the `top_p` parameter.
 func (r Request[T]) WithTopP(topp float64) Request[T] {
 	r.TopP = &topp
+
+	return r
+}
+
+func (r Request[T]) WithThinking(thinking bool) Request[T] {
+	r.Thinking = &thinking
 
 	return r
 }


### PR DESCRIPTION
This pull request adds support for a new "thinking" configuration to the Google AI Studio provider, allowing users to specify options such as `IncludeThoughts` and `Budget` in their requests.
To disable thinking mode, set the Budget to 0

**Support for "thinking" configuration:**

* Added a new `ThinkingConfig` struct to `request_options.go`, and extended `RequestOptions` to include an optional `Thinking` field. This allows users to specify `IncludeThoughts` and `Budget` when making requests.
* Updated the request adaptation logic in `aistudio.go` to include the `thinkingConfig` in the request payload when the `Thinking` option is provided.

**Testing enhancements:**

* Added a new test function `TestGoogleAiRequestWithThinking` in `aistudio_test.go` to verify that the `thinkingConfig` fields are correctly included or omitted in the payload based on the provided options. The tests cover cases for no config, only `IncludeThoughts`, only `Budget`, both fields, and disabling thinking.
* Added `github.com/samber/lo` to the imports in `aistudio_test.go` to support pointer creation for test values.